### PR TITLE
LIBFCREPO-513. Allow use of LDPath functions.

### DIFF
--- a/fcrepo-ldpath/src/main/java/org/fcrepo/camel/ldpath/LDPathWrapper.java
+++ b/fcrepo-ldpath/src/main/java/org/fcrepo/camel/ldpath/LDPathWrapper.java
@@ -24,9 +24,11 @@ import java.io.InputStreamReader;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import com.github.jsonldjava.sesame.SesameJSONLDParserFactory;
 import org.apache.marmotta.ldpath.LDPath;
+import org.apache.marmotta.ldpath.api.functions.SelectorFunction;
 import org.apache.marmotta.ldpath.backend.linkeddata.LDCacheBackend;
 import org.apache.marmotta.ldpath.exception.LDPathParseException;
 import org.openrdf.model.Value;
@@ -52,6 +54,20 @@ import org.semarglproject.sesame.rdf.rdfa.SesameRDFaParserFactory;
 public class LDPathWrapper {
 
     private final LDPath<Value> ldpath;
+
+    /**
+     * Create an LDPathWrapper and register a set of selector functions.
+     *
+     * @param backend the linkeddata backend
+     * @param functions selector functions
+     */
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    public LDPathWrapper(final LDCacheBackend backend, final Set<SelectorFunction> functions) {
+        this(backend);
+        for (SelectorFunction<Value> function : functions) {
+            ldpath.registerFunction(function);
+        }
+    }
 
     /**
      * Create an LDPathWrapper Object

--- a/fcrepo-ldpath/src/test/java/org/fcrepo/camel/ldpath/RouteWithFunctionsTest.java
+++ b/fcrepo-ldpath/src/test/java/org/fcrepo/camel/ldpath/RouteWithFunctionsTest.java
@@ -1,0 +1,253 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.camel.ldpath;
+
+import static org.apache.camel.Exchange.CONTENT_TYPE;
+import static org.apache.camel.Exchange.HTTP_METHOD;
+import static org.apache.camel.Exchange.HTTP_URI;
+import static org.apache.camel.util.ObjectHelper.loadResourceAsStream;
+import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
+
+import java.io.File;
+import java.util.Dictionary;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import org.apache.camel.EndpointInject;
+import org.apache.camel.Produce;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.builder.AdviceWithRouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.blueprint.CamelBlueprintTestSupport;
+import org.apache.camel.util.KeyValueHolder;
+import org.apache.marmotta.ldcache.api.LDCachingBackend;
+import org.apache.marmotta.ldcache.backend.file.LDCachingFileBackend;
+import org.junit.Test;
+import org.openrdf.repository.RepositoryException;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Test the route workflow.
+ *
+ * @author acoburn
+ * @since Aug 6, 2016
+ */
+public class RouteWithFunctionsTest extends CamelBlueprintTestSupport {
+
+    private final ObjectMapper MAPPER = new ObjectMapper();
+
+    @EndpointInject(uri = "mock:result")
+    protected MockEndpoint resultEndpoint;
+
+    @Produce(uri = "direct:start")
+    protected ProducerTemplate template;
+
+    @Override
+    public boolean isUseAdviceWith() {
+        return true;
+    }
+
+    @Override
+    public boolean isUseRouteBuilder() {
+        return false;
+    }
+
+    @Override
+    protected String getBlueprintDescriptor() {
+        return "/OSGI-INF/blueprint/blueprint-test.xml";
+    }
+
+    @Override
+    protected void addServicesOnStartup(final Map<String, KeyValueHolder<Object, Dictionary>> services) {
+
+        final String cacheDir = System.getProperty("project.build.directory", "target") +
+                "/ldcache-" + randomAlphabetic(5);
+
+        final LDCachingBackend backend;
+        try {
+            backend = new LDCachingFileBackend(new File(cacheDir));
+            backend.initialize();
+        } catch (final RepositoryException ex) {
+            throw new RuntimeException("Could not initialize LDCache backend at " + cacheDir, ex);
+        }
+        services.put(LDCachingBackend.class.getName(),
+                asService(backend, "osgi.jndi.service.name", "fcrepo/LDCacheBackend"));
+    }
+
+    @Override
+    protected Properties useOverridePropertiesWithPropertiesComponent() {
+        final String restPort = System.getProperty("fcrepo.dynamic.ldpath.port", "9085");
+
+        final Properties props = new Properties();
+        props.put("rest.port", restPort);
+        return props;
+    }
+
+    @Test
+    public void testGetDefault() throws Exception {
+        final String uri = "http://fedora.info/definitions/v4/event#ResourceCreation";
+        resultEndpoint.expectedMessageCount(1);
+        resultEndpoint.expectedHeaderReceived(CONTENT_TYPE, "application/json");
+
+        context.getRouteDefinition("FcrepoLDPathGet").adviceWith(context, new AdviceWithRouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                weaveAddLast().to("mock:result");
+            }
+        });
+        context.start();
+
+        template.sendBodyAndHeader("direct:get", null, "context", uri);
+
+        assertMockEndpointsSatisfied();
+        final String result = resultEndpoint.getExchanges().get(0).getIn().getBody(String.class);
+
+        @SuppressWarnings("unchecked")
+        final List<Map<String, List<String>>> data = MAPPER.readValue(result, List.class);
+
+        assertFalse(data.isEmpty());
+        assertTrue(data.get(0).containsKey("label"));
+        assertTrue(data.get(0).containsKey("type"));
+        assertTrue(data.get(0).get("label").contains("resource creation"));
+        assertTrue(data.get(0).get("type").contains("http://www.w3.org/2000/01/rdf-schema#Class"));
+        assertTrue(data.get(0).get("id").contains(uri));
+    }
+
+    @Test
+    public void testOptions() throws Exception {
+        getMockEndpoint("mock:language:simple:resource:classpath:org/fcrepo/camel/ldpath/options.ttl")
+        .expectedMessageCount(1);
+
+        context.getRouteDefinition("FcrepoLDPathRest").adviceWith(context, new AdviceWithRouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                replaceFromWith("direct:start");
+                mockEndpointsAndSkip("*");
+            }
+        });
+        context.start();
+
+        template.sendBodyAndHeader(null, HTTP_METHOD, "OPTIONS");
+        assertMockEndpointsSatisfied();
+    }
+
+    @Test
+    public void testGetParam() throws Exception {
+        final String uri = "http://fedora.info/definitions/v4/repository#Binary";
+        getMockEndpoint("mock:http4:localhost").expectedMessageCount(1);
+        getMockEndpoint("mock:http4:localhost").expectedHeaderReceived(HTTP_URI, "http://example.org/ldpath");
+
+        resultEndpoint.expectedMessageCount(1);
+        resultEndpoint.expectedHeaderReceived(CONTENT_TYPE, "application/json");
+
+        context.getRouteDefinition("FcrepoLDPathGet").adviceWith(context, new AdviceWithRouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                mockEndpointsAndSkip("http4:*");
+                weaveAddLast().to("mock:result");
+            }
+        });
+        context.start();
+
+        final Map<String, Object> headers = new HashMap<>();
+        headers.put("ldpath", "http://example.org/ldpath");
+        headers.put("context", uri);
+        template.sendBodyAndHeaders("direct:get", loadResourceAsStream("test.ldpath"), headers);
+
+        assertMockEndpointsSatisfied();
+        final String result = resultEndpoint.getExchanges().get(0).getIn().getBody(String.class);
+
+        @SuppressWarnings("unchecked")
+        final List<Map<String, List<String>>> data = MAPPER.readValue(result, List.class);
+
+        assertFalse(data.isEmpty());
+        assertTrue(data.get(0).containsKey("label"));
+        assertTrue(data.get(0).containsKey("type"));
+        assertTrue(data.get(0).get("label").contains("binary"));
+        assertTrue(data.get(0).get("type").contains("Class"));
+        assertTrue(data.get(0).get("id").contains(uri));
+    }
+
+    @Test
+    public void testMimicPost() throws Exception {
+        final String uri = "http://fedora.info/definitions/v4/repository#Container";
+        resultEndpoint.expectedMessageCount(1);
+        resultEndpoint.expectedHeaderReceived(CONTENT_TYPE, "application/json");
+
+        context.getRouteDefinition("FcrepoLDPathPrepare").adviceWith(context, new AdviceWithRouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                weaveAddLast().to("mock:result");
+            }
+        });
+        context.start();
+
+        template.sendBodyAndHeader("direct:ldpathPrepare", loadResourceAsStream("test.ldpath"), "context", uri);
+
+        assertMockEndpointsSatisfied();
+        final String result = resultEndpoint.getExchanges().get(0).getIn().getBody(String.class);
+
+        @SuppressWarnings("unchecked")
+        final List<Map<String, List<String>>> data = MAPPER.readValue(result, List.class);
+
+        assertFalse(data.isEmpty());
+        assertTrue(data.get(0).containsKey("label"));
+        assertTrue(data.get(0).containsKey("type"));
+        assertTrue(data.get(0).get("label").contains("Fedora Container"));
+        assertTrue(data.get(0).get("type").contains("Class"));
+        assertTrue(data.get(0).get("id").contains(uri));
+
+    }
+
+    @Test
+    public void testMimicPostWithFunctions() throws Exception {
+        final String uri = "http://fedora.info/definitions/v4/repository#Container";
+        resultEndpoint.expectedMessageCount(1);
+        resultEndpoint.expectedHeaderReceived(CONTENT_TYPE, "application/json");
+
+        context.getRouteDefinition("FcrepoLDPathPrepare").adviceWith(context, new AdviceWithRouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                weaveAddLast().to("mock:result");
+            }
+        });
+        context.start();
+
+        template.sendBodyAndHeader("direct:ldpathPrepare", loadResourceAsStream("test-with-functions.ldpath"),
+                "context", uri);
+
+        assertMockEndpointsSatisfied();
+        final String result = resultEndpoint.getExchanges().get(0).getIn().getBody(String.class);
+
+        @SuppressWarnings("unchecked")
+        final List<Map<String, List<String>>> data = MAPPER.readValue(result, List.class);
+
+        assertFalse(data.isEmpty());
+        assertTrue(data.get(0).containsKey("label"));
+        assertTrue(data.get(0).containsKey("type"));
+        assertTrue(data.get(0).containsKey("description"));
+        assertTrue(data.get(0).get("label").contains("Fedora Container"));
+        assertTrue(data.get(0).get("type").contains("Class"));
+        assertTrue(data.get(0).get("id").contains(uri));
+        assertTrue(data.get(0).get("description").contains("Class : Fedora Container"));
+
+    }
+}

--- a/fcrepo-ldpath/src/test/resources/OSGI-INF/blueprint/blueprint-with-functions-test.xml
+++ b/fcrepo-ldpath/src/test/resources/OSGI-INF/blueprint/blueprint-with-functions-test.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
+       xsi:schemaLocation="
+       http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0 http://aries.apache.org/schemas/blueprint-cm/blueprint-cm-1.1.0.xsd
+       http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
+       http://camel.apache.org/schema/blueprint http://camel.apache.org/schema/blueprint/camel-blueprint.xsd">
+
+   <!-- OSGI blueprint property placeholder -->
+   <cm:property-placeholder id="properties" persistent-id="org.fcrepo.camel.ldpath" update-strategy="reload">
+     <cm:default-properties>
+       <cm:property name="fcrepo.authUsername" value=""/>
+       <cm:property name="fcrepo.authPassword" value=""/>
+       <cm:property name="fcrepo.authHostname" value="localhost"/>
+       <cm:property name="fcrepo.authPort" value="8080"/>
+       <cm:property name="fcrepo.baseUrl" value="http://localhost:8080/fcrepo/rest"/>
+       <cm:property name="fcrepo.cache.timeout" value="0"/>
+       <cm:property name="rest.prefix" value="/ldpath"/>
+       <cm:property name="rest.host" value="localhost"/>
+       <cm:property name="rest.port" value="9085"/>
+       <cm:property name="cache.timeout" value="86400"/>
+     </cm:default-properties>
+   </cm:property-placeholder>
+
+   <reference id="backend" interface="org.apache.marmotta.ldcache.api.LDCachingBackend" filter="(osgi.jndi.service.name=fcrepo/LDCacheBackend)"/>
+
+   <bean id="credentials" class="org.apache.http.auth.UsernamePasswordCredentials">
+     <argument index="0" value="${fcrepo.authUsername}"/>
+     <argument index="1" value="${fcrepo.authPassword}"/>
+   </bean>
+
+   <bean id="authScope" class="org.apache.http.auth.AuthScope">
+     <argument index="0" type="java.lang.String" value="${fcrepo.authHostname}"/>
+     <argument index="1" type="int" value="${fcrepo.authPort}"/>
+   </bean>
+
+   <bean id="fcrepoHttpClientBuilder" class="org.fcrepo.client.FcrepoHttpClientBuilder">
+     <argument index="0" type="java.lang.String" value="${fcrepo.authUsername}"/>
+     <argument index="1" type="java.lang.String" value="${fcrepo.authPassword}"/>
+     <argument index="2" type="java.lang.String" value="${fcrepo.authHostname}"/>
+   </bean>
+
+   <bean id="client" class="org.fcrepo.camel.ldpath.ClientFactory" factory-method="createClient">
+     <argument ref="authScope"/>
+     <argument ref="credentials"/>
+     <argument>
+       <list>
+         <bean class="org.fcrepo.camel.ldpath.FedoraEndpoint">
+           <argument index="0" type="java.lang.String" value="${fcrepo.baseUrl}"/>
+           <argument index="1" type="java.lang.Long" value="${fcrepo.cache.timeout}"/>
+         </bean>
+       </list>
+     </argument>
+     <argument>
+       <list>
+         <bean class="org.fcrepo.camel.ldpath.FedoraProvider">
+           <argument ref="fcrepoHttpClientBuilder"/>
+         </bean>
+       </list>
+     </argument>
+   </bean>
+
+   <bean id="config" class="org.apache.marmotta.ldcache.model.CacheConfiguration">
+     <argument ref="client"/>
+     <property name="defaultExpiry" value="${cache.timeout}"/>
+   </bean>
+
+   <bean id="ldcache" class="org.apache.marmotta.ldcache.services.LDCache">
+     <argument ref="config"/>
+     <argument ref="backend"/>
+   </bean>
+
+   <bean id="ldcachebackend" class="org.apache.marmotta.ldpath.backend.linkeddata.LDCacheBackend">
+     <argument ref="ldcache"/>
+   </bean>
+
+   <bean id="ldpath" class="org.fcrepo.camel.ldpath.LDPathWrapper">
+     <argument ref="ldcachebackend"/>
+     <argument>
+       <set>
+         <bean class="org.apache.marmotta.ldpath.model.functions.ConcatenateFunction"/>
+         <bean class="org.apache.marmotta.ldpath.model.functions.FirstFunction"/>
+       </set>
+     </argument>
+   </bean>
+
+  <camelContext id="FcrepoLDPathContext" depends-on="ldpath" xmlns="http://camel.apache.org/schema/blueprint">
+    <package>org.fcrepo.camel.ldpath</package>
+
+    <route id="FcrepoLDPath">
+      <from uri="direct:ldpath"/>
+      <setBody>
+        <method ref="ldpath" method="programQuery(${headers.context}, ${body})"/>
+      </setBody>
+    </route>
+
+  </camelContext>
+
+</blueprint>

--- a/fcrepo-ldpath/src/test/resources/test-with-functions.ldpath
+++ b/fcrepo-ldpath/src/test/resources/test-with-functions.ldpath
@@ -1,0 +1,6 @@
+id      = . :: xsd:string ;
+
+type = rdf:type / rdfs:label :: xsd:string ;
+label = rdfs:label :: xsd:string ;
+comment = rdfs:comment :: xsd:string ;
+description = fn:concat(rdf:type / rdfs:label, " : ", rdfs:label) :: xsd:string ;


### PR DESCRIPTION
Added 2-arg constructor to LDPathWrapper that takes a set of functions to register.

https://issues.umd.edu/browse/LIBFCREPO-513